### PR TITLE
Handle service account conditions when assigning roles

### DIFF
--- a/deploy_solution.sh
+++ b/deploy_solution.sh
@@ -41,6 +41,9 @@ if [ -n "$NEW_SERVICE_ACCOUNT" ]; then
 fi
 
 echo "Assigning required roles to the service account ${SERVICE_ACCOUNT}"
+# Iterate over the roles and check if the service account already has that role
+# assigned. If it has then skip adding that policy binding as using
+# --condition=None can overwrite any existing conditions in the binding.
 CURRENT_POLICY=$(gcloud projects get-iam-policy ${PROJECT_ID} --format=json)
 MEMBER="serviceAccount:${SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com"
 


### PR DESCRIPTION
Check if an IAM policy binding already exists (which might already have some IAM conditions), if it does then skip assigning the role. Else create an IAM policy binding with `--condition=None`.